### PR TITLE
removed use of a variable in IsPalindrome function

### DIFF
--- a/problem-4/Euler Project Question 4/main.cpp
+++ b/problem-4/Euler Project Question 4/main.cpp
@@ -20,11 +20,9 @@ string LongToAscii(unsigned long _iElem){
 }
 
 bool IsPalindrome(long lNumber){
-	//It should work correctly
 	string strNumber = LongToAscii(lNumber);
-	unsigned long j = strNumber.length() - 1;
-	for (int i = 0; i < strNumber.length() - 1 / 2; i++, j--) {
-		if(strNumber.at(i) != strNumber.at(j))
+	for (int i = 0, m = strNumber.length(); i < m/ 2; i++) {
+		if(strNumber.at(i) != strNumber.at(m-i-1))
 			return false;
 	}
 	return true;


### PR DESCRIPTION
Also fixed a problem with the following line : 

``` cpp
strNumber.length() - 1 / 2
```

Would have been correct with

``` cpp
(strNumber.length() / 2
```
